### PR TITLE
Picture helper - Add empty alt attribute to img element

### DIFF
--- a/src/ImageProcessor.Web.Episerver/Extensions/PictureHelper.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/PictureHelper.cs
@@ -59,7 +59,8 @@ namespace ImageProcessor.Web.Episerver
 
             //create img element
             var imgElement = new TagBuilder("img");
-            imgElement.Attributes.Add("src", BuildQueryString(imageUrl, imageType, imageType.DefaultImgWidth));
+	        imgElement.Attributes.Add("alt", "");
+			imgElement.Attributes.Add("src", BuildQueryString(imageUrl, imageType, imageType.DefaultImgWidth));
             if (!string.IsNullOrEmpty(cssClass))
             {
                 imgElement.Attributes.Add("class", cssClass);


### PR DESCRIPTION
Add empty alt attribute to img element, so that SEO analyzer etc. don't report it as lousy markup.
FYI: couldn't get the sample alloy site in the repo to work. Database is newer than the code.