### PR TITLE
Allow for a relative app data path as well

### DIFF
--- a/src/ImageProcessor.Web.Episerver/FileBlobCache.cs
+++ b/src/ImageProcessor.Web.Episerver/FileBlobCache.cs
@@ -97,7 +97,7 @@ namespace ImageProcessor.Web.Episerver
         public FileBlobCache(string requestPath, string fullPath, string querystring)
             : base(requestPath, fullPath, querystring)
         {
-            string basePath = (EPiServerFrameworkSection.Instance.AppData.BasePath.IndexOf(@"\\") == 0 || EPiServerFrameworkSection.Instance.AppData.BasePath.Contains(":\\"))
+            string basePath = (EPiServerFrameworkSection.Instance.AppData.BasePath.IndexOf(@"\\") == 0 || EPiServerFrameworkSection.Instance.AppData.BasePath.StartsWith(@"..\") || EPiServerFrameworkSection.Instance.AppData.BasePath.Contains(":\\"))
                                         ? EPiServerFrameworkSection.Instance.AppData.BasePath
                                         : "~/" + EPiServerFrameworkSection.Instance.AppData.BasePath;
 


### PR DESCRIPTION
In this old issue https://github.com/vnbaaij/ImageProcessor.Web.Episerver/issues/25 you fixed the path for the cache to be able to handle absolute paths but it could not handle a relative path (starting with ..\) so i added that as well. 