### PR TITLE
Picture helper: Support for native lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Example usage
 @Html.Picture(Model.Image, ImageTypes.Teaser)
 
 @* Url (string) as input + render for progressive lazy loading *@
-@Html.Picture(Url.ContentUrl(Model.Image), ImageTypes.Teaser, lazyLoadType: LazyLoadType.Progressive)
+@Html.Picture(Url.ContentUrl(Model.Image), ImageTypes.Teaser, LazyLoadType.CustomProgressive)
 
 @* Picture helper can be used together with the ProcessImage helper *@
 @Html.Picture(Html.ProcessImage(Model.Image).ReplaceColor("fff", "f00", 99).Watermark("Episerver", new Point(100, 100), "fff"), ImageTypes.Teaser)
@@ -73,10 +73,12 @@ Example usage
 * **imageType (ImageProcessor.Web.Episerver.ImageType)** <br/> An "Image type" defines the possible sizes and quality for an image. <br/> [Example of how to define image types](https://github.com/vnbaaij/ImageProcessor.Web.Episerver/blob/master/samples/AlloySampleLocal/Business/Rendering/ImageTypes.cs)
 * **cssClass (string)** <br/> Will be added to the rendered img element.
 * **layzLoadType (ImageProcessor.Web.Episerver.LazyLoadType)** <br/> 
-When lazy load type is "Regular", the srcset attribute of the source element (inside the rendered picture element) will be empty, 
+Set lazy load type to "Native" to have a browser-native lazy loaded image. The attribute "loading='lazy'" is added to the img element.<br/>
+When lazy load type is "Custom", the srcset attribute of the source element (inside the rendered picture element) will be empty, 
 and an additional attribute (data-srcset) will be added that contains the image url(s). 
 That enables you to lazy load the image after the rest of your page content is loaded. <br/>
-When lazy load type is "Progressive", the srcset attribute will contain image url(s) for a low quality version of the image, and makes it possible to lazy load the high quality image.<br/>
+When lazy load type is "CustomProgressive", the srcset attribute will contain image url(s) for a low quality version of the image, and makes it possible to lazy load the high quality image.<br/>
+Lazy load type "Hybrid" render the same as "Custom", and also adds the "loading='lazy'" attribute. That means you can have native lazy loading combined with custom lazy loading for browsers that doesn't support native lazy loading.  <br/>
 [Javascript example of how to lazy load the images](https://github.com/vnbaaij/ImageProcessor.Web.Episerver/blob/master/samples/AlloySampleLocal/Static/js/lazyImages.js)<br/>
 * **altText (string)** <br/> Will be added to the rendered img element.<br/>
 See also how to [get alt text from the image](PICTURE_HELPER_DOC.md).

--- a/samples/AlloySampleLocal/Static/js/lazyImages.js
+++ b/samples/AlloySampleLocal/Static/js/lazyImages.js
@@ -1,13 +1,11 @@
 ﻿
-
-
 function initializeLazyImages() {
   // Get images that has the data-src attribute
   const lazyImages = document.querySelectorAll('img[data-src]');
 
-  // If browser doesn't support IntersectionObserver, load all images 
+  // Just load the images if browser doesn't support IntersectionObserver (Assuming that there is no browser that supports native lazy loading, but doesn't support IntersectionObserver). 
   if (!('IntersectionObserver' in window)) {
-    lazyImages.forEach((imageElement) => loadImage(imageElement));
+    lazyImages.forEach((imageElement) => setSrcAttribute(imageElement));
     return;
   }
 
@@ -19,7 +17,7 @@ function initializeLazyImages() {
         }
 
         const imageElement = entry.target;
-        loadImage(imageElement);
+        setSrcAttribute(imageElement);
         observer.unobserve(imageElement);
       });
     },
@@ -27,13 +25,19 @@ function initializeLazyImages() {
     { rootMargin: '100px' } // load images if it gets within 100px
   ); 
 
-  // Let all lazy images be observered
+
   lazyImages.forEach((imageElement) => {
-    observer.observe(imageElement);
+    if (imageElement.loading === 'lazy' && 'loading' in HTMLImageElement.prototype) {
+      // Set src attribute if image element is using native lazy loading (and the browser supports it)
+      setSrcAttribute(imageElement);
+    } else {
+      // Let the image be observed
+      observer.observe(imageElement);
+    }
   });
 }
 
-function loadImage(imageElement) {
+function setSrcAttribute(imageElement) {
   // If image is within a picture element, set srcset attribute for all source elements
   const parent = imageElement.parentNode;
   if (parent.tagName === 'PICTURE') {
@@ -45,4 +49,6 @@ function loadImage(imageElement) {
 
   // Set img src attribute
   imageElement.src = imageElement.dataset.src;
+  console.log(imageElement.src);
+
 }

--- a/samples/AlloySampleLocal/Views/Shared/Blocks/TeaserBlock.cshtml
+++ b/samples/AlloySampleLocal/Views/Shared/Blocks/TeaserBlock.cshtml
@@ -17,21 +17,33 @@
         <h2 @Html.EditAttributes(x => x.Heading)>@Model.Heading</h2>
         <p @Html.EditAttributes(x => x.Text)>@Model.Text</p>
         <div @Html.EditAttributes(x => x.Image)>
-            @Html.Picture(Html.ProcessImage(Model.Image).Resize(378, null).ReplaceColor("fff", "f00", 99).Watermark("Episerver", new Point(100, 100), "fff"), ImageTypes.Teaser, lazyLoadType: LazyLoadType.Regular)
-            @Html.Picture(Html.ProcessImage(Model.Image).Resize(378, null, ImageProcessor.Imaging.ResizeMode.Crop).ReplaceColor("fff", "f00", 99).Watermark("Episerver", new Point(100, 100), "fff"), ImageTypes.Teaser, lazyLoadType: LazyLoadType.None)
-            @Html.Picture(Html.ProcessImage(Model.Image).Quality(32).Resize(null, null, ResizeMode.Stretch), ImageTypes.Teaser, lazyLoadType: LazyLoadType.Progressive)
-            @Html.Picture(Html.ProcessImage(Model.Image).Quality(32), ImageTypes.Teaser, lazyLoadType: LazyLoadType.None, altText: "Picture helper rocks!\"/><script>alert('this is unsafe!')</script>")
-            @Html.Picture(Url.ContentUrl(Model.Image), ImageTypes.Teaser)
-            @Html.Picture(Model.Image, ImageTypes.Teaser)
+            @*@Html.Picture(Html.ProcessImage(Model.Image).Resize(378, null).ReplaceColor("fff", "f00", 99).Watermark("Episerver", new Point(100, 100), "fff"), ImageTypes.Teaser, lazyLoadType: LazyLoadType.Custom)
+        @Html.Picture(Html.ProcessImage(Model.Image).Resize(378, null, ImageProcessor.Imaging.ResizeMode.Crop).ReplaceColor("fff", "f00", 99).Watermark("Episerver", new Point(100, 100), "fff"), ImageTypes.Teaser, lazyLoadType: LazyLoadType.None)
+        @Html.Picture(Html.ProcessImage(Model.Image).Quality(32).Resize(null, null, ResizeMode.Stretch), ImageTypes.Teaser, lazyLoadType: LazyLoadType.CustomProgressive)
+        @Html.Picture(Html.ProcessImage(Model.Image).Quality(32), ImageTypes.Teaser, lazyLoadType: LazyLoadType.None, altText: "Picture helper rocks!\"/><script>alert('this is unsafe!')</script>")
+        @Html.Picture(Model.Image, ImageTypes.Teaser)*@
+            @* A really long page is needed when testing native lazy loading  *@
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+            <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+
+            @Html.Picture(Url.ContentUrl(Model.Image) + "?watermark=test", ImageTypes.Teaser, LazyLoadType.Custom)
+            @Html.Picture(Url.ContentUrl(Model.Image) + "?watermark=test2", ImageTypes.Teaser, LazyLoadType.Hybrid)
+            @Html.Picture(Url.ContentUrl(Model.Image) + "?watermark=test3", ImageTypes.Teaser, LazyLoadType.Native)
             <pre>
                 @{
                     var picData = PictureUtils.GetPictureData(Model.Image, ImageTypes.Teaser, true);
                     @picData.SrcSet <br />
-
                     @picData.SrcSetLowQuality<br />
-
                     @picData.SrcSetWebp<br />
-
                     @picData.SizesAttribute<br />
 
                     @picData.AltText<br />

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/Enums.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/Enums.cs
@@ -10,7 +10,13 @@ namespace ImageProcessor.Web.Episerver
 	public enum LazyLoadType
 	{
 		None,
-		Regular,
-		Progressive
+		Custom,
+        CustomProgressive,
+		[Obsolete("Use \"Custom\" instead.")]
+		Regular = Custom,
+		[Obsolete("Use \"CustomProgressive\" instead.")]
+        Progressive = CustomProgressive,
+		Native,
+		Hybrid
 	}
 }


### PR DESCRIPTION
- Added options for rendering attribute for browser-native lazy loading.
Adding and renaming values in Lazyloading enum. Keeping the old ones, but marked as obsolete, so no breaking change.
- Added overloading methods for Picture helper to simplify usage.

A pull request for updating documentation is on it's way 😃.