### PR TITLE
Fixed GetCropUrl to use Width/Height instead of offsets

### DIFF
--- a/src/ImageProcessor.Web.Episerver.UI.Crop/ExtensionMethods/ImageReferenceExtensions.cs
+++ b/src/ImageProcessor.Web.Episerver.UI.Crop/ExtensionMethods/ImageReferenceExtensions.cs
@@ -34,7 +34,7 @@ namespace ImageProcessor.Web.Episerver.UI.Crop.ExtensionMethods
 
                 if (imageReference.CropDetails != null)
                     urlBuilder.QueryCollection.Add("crop",
-                        $"{imageReference.CropDetails.X},{imageReference.CropDetails.Y},{imageReference.CropDetails.X + imageReference.CropDetails.Width},{imageReference.CropDetails.Y + imageReference.CropDetails.Height}");
+                        $"{imageReference.CropDetails.X},{imageReference.CropDetails.Y},{imageReference.CropDetails.Width},{imageReference.CropDetails.Height}");
 
                 if (width.HasValue && width > 0)
                     urlBuilder.Width(width.Value);


### PR DESCRIPTION
Changed GetCropUrl to use height and width in order to conform with the ImageProcessor crop documentation.