### PR TITLE
Picture helper improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ GetPictureData parameters are similar to the parameters for the Picture html hel
 ## Change log
 To get a more exact overview of the changes, you can also take a look at the commit history.
 #### V5.8.0
-- Picture helper: Possible to create WebP versions for other formats than jpg. Add formats to the `CreateWebpForFormat` array in your Image Type. See also #40.
-- Picture helper: `decoding="async"` is now by default added to the img element. Can be changed by setting `ImageDecoding`in your Image Type.
+- Picture helper: Possible to create Webp versions for other formats than jpg. Add formats to the `CreateWebpForFormat` array in the Image Type. See also issue #40.
+- Picture helper: Webp versions of png images will lossless by default. Can be changed by setting `CreateLosslessWebpForPng` in the Image Type.
+- Picture helper: `decoding="async"` is now by default added to the img element. Can be changed by setting `ImageDecoding`in the Image Type.
 - Picture helper: `DefaultImgWidth` is now optional. Will use the largest `SrcSetWidth` if not set.
 #### V5.7.0 
 - Fix unhandled HttpException in FileBlobCache

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Alternatively you could supply the image with all the parameters in the HTML:
 See http://imageprocessor.org/imageprocessor-web/imageprocessingmodule/ for all options
 
 ## Picture Helper
-This package also include an Html helper that renders a [Picture element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) that let's you have responsive, optimized, and lazy loaded images.
+ImageProcessor.Web.Episerver also include an Html helper that renders a [Picture element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) that let's you have responsive, optimized, and lazy loaded images.
 
 Example usage
 ```
@@ -86,7 +86,7 @@ See also how to [get alt text from the image](PICTURE_HELPER_DOC.md).
 The picture helper is described in more detail [here](https://hacksbyme.net/2018/10/19/a-dead-easy-way-to-optimize-the-images-on-your-episerver-site/).
 
 ### Custom rendering of a picture element
-If you can't use the Picture html helper, for instance when rendering the markup client side in a React app, you can still use PictureUtils to get the data needed to render a picture element.
+If you for some reason wnat to render the markup yourself, you can use PictureUtils to get the data needed to render a picture element.
 ````
 PictureUtils.GetPictureData(myImageRef, ImageTypes.Teaser)
 ````
@@ -95,6 +95,10 @@ GetPictureData parameters are similar to the parameters for the Picture html hel
 
 ## Change log
 To get a more exact overview of the changes, you can also take a look at the commit history.
+#### V5.8.0
+- Picture helper: Possible to create WebP versions for other formats than jpg. Add formats to the `CreateWebpForFormat` array in your Image Type. See also #40.
+- Picture helper: `decoding="async"` is now by default added to the img element. Can be changed by setting `ImageDecoding`in your Image Type.
+- Picture helper: `DefaultImgWidth` is now optional. Will use the largest `SrcSetWidth` if not set.
 #### V5.7.0 
 - Fix unhandled HttpException in FileBlobCache
 - Fix AzureBlobCache.TrimCacheAsync erro when blob already deleted

--- a/samples/AlloySampleLocal/Business/Rendering/ImageTypes.cs
+++ b/samples/AlloySampleLocal/Business/Rendering/ImageTypes.cs
@@ -11,7 +11,6 @@ namespace AlloySample.Business.Rendering
         // A full width Hero image is very simple, since its always 100% of the viewport width.
         public static ImageType HeroImage = new ImageType
         {
-            DefaultImgWidth = 1280,
             SrcSetWidths = new[] { 375, 750, 1440, 1920 },
             SrcSetSizes = new[] { "100vw" },
             HeightRatio = 0.5625 //16:9
@@ -19,7 +18,6 @@ namespace AlloySample.Business.Rendering
 
         public static ImageType Thumbnail = new ImageType
         {
-            DefaultImgWidth = 200,
             SrcSetWidths = new[] { 200, 400 },
             SrcSetSizes = new[] { "200px" },
             HeightRatio = 1 //square
@@ -33,7 +31,6 @@ namespace AlloySample.Business.Rendering
         // Note that the "viewable width" is not the same as the image file width (but it can be, on a screen with a "device pixel ratio" of 1).
         public static ImageType Teaser = new ImageType
         {
-            DefaultImgWidth = 750,
             SrcSetWidths = new[] { 375, 750, 980, 1500 }, //adding a bunch of sizes for demo purpose. In a real world scenario I wouldn't have this many.
             SrcSetSizes = new[] { "(max-width: 980px) calc((100vw - 40px)), (max-width: 1200px) 368px, 750px" },
 	        HeightRatio = 0.5625 //16:9

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/Enums.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/Enums.cs
@@ -20,3 +20,16 @@ namespace ImageProcessor.Web.Episerver
 		Hybrid
 	}
 }
+
+namespace ImageProcessor.Web.Episerver.Picture
+{
+    public enum ImageDecoding
+    {
+        Async,
+        Sync,
+        Auto,
+        None
+    }
+}
+
+

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ImageProcessor.Web.Episerver.Picture;
 
 //TODO: namespace should be ImageProcessor.Web.Episerver.Picture, but wait for other breaking changes(?)
 namespace ImageProcessor.Web.Episerver
@@ -33,10 +34,16 @@ namespace ImageProcessor.Web.Episerver
 		/// </summary>
         public ImageFormat[] CreateWebpForFormat { get; set; }
 
+        /// <summary>
+        /// Img element decoding attribute.
+        /// </summary>
+        public ImageDecoding ImageDecoding { get; set; }
+
 		public ImageType()
 		{
 			Quality = 80;
             CreateWebpForFormat = new ImageFormat[] { ImageFormat.Jpg, ImageFormat.Jpeg };
-        }
+            ImageDecoding = ImageDecoding.Async;
+		}
 	}
 }

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
@@ -28,9 +28,15 @@ namespace ImageProcessor.Web.Episerver
 		/// </summary>
 		public int Quality { get; set; }
 
+		/// <summary>
+		/// Create Webp versions for these image formats.
+		/// </summary>
+        public ImageFormat[] CreateWebpForFormat { get; set; }
+
 		public ImageType()
 		{
 			Quality = 80;
-		}
+            CreateWebpForFormat = new ImageFormat[] { ImageFormat.Jpg, ImageFormat.Jpeg };
+        }
 	}
 }

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
@@ -48,6 +48,11 @@ namespace ImageProcessor.Web.Episerver
 		/// </summary>
         public ImageFormat[] CreateWebpForFormat { get; set; }
 
+		/// <summary>
+		/// Create lossless Webp versions for images in png format.
+		/// </summary>
+		public bool CreateLosslessWebpForPng { get; set; }
+
         /// <summary>
         /// Img element decoding attribute.
         /// </summary>
@@ -56,7 +61,8 @@ namespace ImageProcessor.Web.Episerver
 		public ImageType()
 		{
 			Quality = 80;
-            CreateWebpForFormat = new ImageFormat[] { ImageFormat.Jpg, ImageFormat.Jpeg };
+            CreateWebpForFormat = new ImageFormat[] { ImageFormat.Jpg, ImageFormat.Jpeg, ImageFormat.Png };
+            CreateLosslessWebpForPng = true;
             ImageDecoding = ImageDecoding.Async;
 		}
 	}

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/ImageType.cs
@@ -10,10 +10,24 @@ namespace ImageProcessor.Web.Episerver
 {
 	public class ImageType
 	{
+        private int? _defaultImgWidth;
+
 		/// <summary>
 		/// This size will be used in browsers that don't support the picture element.
+		/// Will use the largest SrcSetWidth if not set.
 		/// </summary>
-		public int? DefaultImgWidth { get; set; }
+		public int? DefaultImgWidth
+        {
+            get
+            {
+                if (_defaultImgWidth == default && SrcSetWidths != null)
+                {
+                    return SrcSetWidths.Max();
+                }
+                return _defaultImgWidth;
+            }
+            set => _defaultImgWidth = value;
+        }
 
 		/// <summary>
 		/// The different image widths that the browser will select from.

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureData.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ImageProcessor.Web.Episerver.Picture;
 
 namespace ImageProcessor.Web.Episerver.Extensions.Picture
 {
@@ -16,5 +17,6 @@ namespace ImageProcessor.Web.Episerver.Extensions.Picture
         public string ImgSrc { get; set; }
         public string ImgSrcLowQuality { get; set; }
         public string AltText { get; set; }
+        public ImageDecoding ImgDecoding { get; set; }
     }
 }

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureHelper.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureHelper.cs
@@ -116,6 +116,11 @@ namespace ImageProcessor.Web.Episerver
 			    imgElement.Attributes.Add("class", cssClass);
 		    }
 
+            if (pictureData.ImgDecoding != ImageDecoding.None)
+            {
+                imgElement.Attributes.Add("decoding", Enum.GetName(typeof(ImageDecoding), pictureData.ImgDecoding)?.ToLower());
+            }
+
 			return imgElement.ToString(TagRenderMode.SelfClosing);
 		}
 

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureUtils.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureUtils.cs
@@ -64,21 +64,21 @@ namespace ImageProcessor.Web.Episerver.Picture
                 AltText = altText
             };
 
-            var currentFormat = GetFormatFromExtension(imageUrl.Path);
+            var currentFormat = GetFormatFromExtension(imageUrl.Path); 
 	        if (imageType.SrcSetWidths != null)
 	        {
-	            pData.SrcSet = BuildSrcSet(imageUrl, imageType, currentFormat);
-                pData.ImgSrc = BuildQueryString(imageUrl, imageType, imageType.DefaultImgWidth, currentFormat);
+	            pData.SrcSet = BuildSrcSet(imageUrl, imageType, currentFormat.ToString().ToLower()); //TODO: use ImageProcessor.Web.Episerver.ImageFormat everywhere, instead of a string value.
+				pData.ImgSrc = BuildQueryString(imageUrl, imageType, imageType.DefaultImgWidth, currentFormat.ToString().ToLower());
 	            pData.SizesAttribute = string.Join(", ", imageType.SrcSetSizes);
 
 	            if (includeLowQuality)
 	            {
-	                pData.SrcSetLowQuality = BuildSrcSet(imageUrl, imageType, currentFormat, true);
-	                pData.ImgSrcLowQuality = BuildQueryString(imageUrl, imageType, imageType.DefaultImgWidth, currentFormat, 10);
+	                pData.SrcSetLowQuality = BuildSrcSet(imageUrl, imageType, currentFormat.ToString().ToLower(), true);
+	                pData.ImgSrcLowQuality = BuildQueryString(imageUrl, imageType, imageType.DefaultImgWidth, currentFormat.ToString().ToLower(), 10);
 	            }
 
-                //if jpg, also add webp versions
-                if (currentFormat == "jpg")
+				//Add webp versions for the specified image formats
+				if (imageType.CreateWebpForFormat != null && imageType.CreateWebpForFormat.Contains(currentFormat))
 	            {
 	                pData.SrcSetWebp = BuildSrcSet(imageUrl, imageType, "webp");
 	                if (includeLowQuality)
@@ -113,13 +113,11 @@ namespace ImageProcessor.Web.Episerver.Picture
 	        return srcset;
 	    }
 
-        private static string GetFormatFromExtension(string filePath)
+        private static ImageFormat GetFormatFromExtension(string filePath)
 		{
-			var extension = Path.GetExtension(filePath);
-			var format = extension?.TrimStart('.');
-			if (format == "jpeg")
-				format = "jpg";
-			return format ?? string.Empty;
+			var extension = Path.GetExtension(filePath)?.TrimStart('.');
+            Enum.TryParse<ImageFormat>(extension, true, out var format);
+            return format;
 		}
 
 		private static string BuildQueryString(UrlBuilder imageUrl, ImageType imageType, int? imageWidth, string format, int? overrideQuality = null)

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureUtils.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureUtils.cs
@@ -61,7 +61,8 @@ namespace ImageProcessor.Web.Episerver.Picture
 	    {
             var pData = new PictureData
             {
-                AltText = altText
+                AltText = altText,
+				ImgDecoding = imageType.ImageDecoding
             };
 
             var currentFormat = GetFormatFromExtension(imageUrl.Path); 

--- a/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureUtils.cs
+++ b/src/ImageProcessor.Web.Episerver/Extensions/Picture/PictureUtils.cs
@@ -81,7 +81,13 @@ namespace ImageProcessor.Web.Episerver.Picture
 				//Add webp versions for the specified image formats
 				if (imageType.CreateWebpForFormat != null && imageType.CreateWebpForFormat.Contains(currentFormat))
 	            {
-	                pData.SrcSetWebp = BuildSrcSet(imageUrl, imageType, "webp");
+                    int? overrideQuality = null;
+                    if (currentFormat == ImageFormat.Png && imageType.CreateLosslessWebpForPng)
+                    {
+                        //set quality to 100 to create lossless Webp when current format is png.
+                        overrideQuality = 100;
+                    }
+					pData.SrcSetWebp = BuildSrcSet(imageUrl, imageType, "webp", false, overrideQuality);
 	                if (includeLowQuality)
 	                {
 	                    pData.SrcSetLowQualityWebp = BuildSrcSet(imageUrl, imageType, "webp", true);
@@ -92,7 +98,8 @@ namespace ImageProcessor.Web.Episerver.Picture
 	        return pData;
 	    }
 
-	    private static string BuildSrcSet(UrlBuilder imageUrl, ImageType imageType, string format, bool lowQuality = false)
+		//TODO: "lowQuality" should be refactored out from this method.
+	    private static string BuildSrcSet(UrlBuilder imageUrl, ImageType imageType, string format, bool lowQuality = false, int? overrideQuality = null)
 	    {
 	        var lowQualityValue = format == "webp" ? 1 : 10; //webp can have lower quality value
 	        var lowQualityFormat = format == "png" ? "png8" : format; //low quality png will be 8-bit
@@ -106,7 +113,7 @@ namespace ImageProcessor.Web.Episerver.Picture
                 }
                 else
 	            {
-	                srcset += BuildQueryString(imageUrl, imageType, width, format) + " " + width + "w, ";
+	                srcset += BuildQueryString(imageUrl, imageType, width, format, overrideQuality) + " " + width + "w, ";
                 }
             }
 	        srcset = srcset.TrimEnd(',', ' ');


### PR DESCRIPTION
- Picture helper: Possible to create Webp versions for other formats than jpg. Add formats to the `CreateWebpForFormat` array in the Image Type. 
- Picture helper: Webp versions of png images will lossless by default. Can be changed by setting `CreateLosslessWebpForPng` in the Image Type.
- Picture helper: `decoding="async"` is now by default added to the img element. Can be changed by setting `ImageDecoding`in the Image Type.
- Picture helper: `DefaultImgWidth` is now optional. Will use the largest `SrcSetWidth` if not set.